### PR TITLE
Set large unused Instapage form fields to empty before submit form

### DIFF
--- a/leads-form-manager.js
+++ b/leads-form-manager.js
@@ -15,13 +15,12 @@ window.instapageFormSubmitSuccess = function (form) {
         return;
     }
 
+    // Remove unwanted 'form data' prior to submission
+    ['lpsSubmissionConfig'].forEach(key => {
+        form.querySelector(`input[name="${key}"]`).value = '';
+    });
+
     // Modify form to POST to FunnelFlux w/ form-data on submit
     form.action = ffluxSubmitUrl;
     form.submit();
 };
-
-/**
- * Notes for documentaion
- * - make sure Instapage's Form's Submission's Destination & Thank-You Message fields are set to blank
- * - You can either have a leads form, OR a multi-part form. not both!
- */


### PR DESCRIPTION
Because FunnelFlux treats both url params and form data as `$_REQUEST`, keyvalues, formdata also become part of `URL Param Accumulation`.

This can cause subsequent redirects to have huge url params.

A temporary fix is to set the main culprit, a hidden field `lpsSubmissionConfig` from Instapage, to `''`, before submitting the form.