### PR TITLE
On submit upsell, POST to callbackUrl w/ params as form-data

### DIFF
--- a/checkout-form-manager-test.html
+++ b/checkout-form-manager-test.html
@@ -3,7 +3,7 @@
   <script src="checkout-form-manager.js"></script>
 </head>
 <body>
-  <a href="//funnel/upsell?offer_id=offer123&callbackUrl=https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1097662607872452933">Upsell 1</a>
+  <a href="//funnel/upsell?offer_id=1360&callbackUrl=https://flux2.astrologyanswers.com/?flux_action=1&flux_f=1147020355678920015&flux_ffn=1147020973846306320">Upsell 1</a>
   <div id="aa-checkout-div"
     data-offer-id="1360"
     data-checkout-button-text="Buy me now!"

--- a/checkout-form-manager.js
+++ b/checkout-form-manager.js
@@ -574,7 +574,7 @@ function updatePricing() {
     if (country !== 'CA') {
         // If the country is not Canada, then no tax
         addPricingRow('Total', offerSubtotal);
-    } else if(state === '') {
+    } else if (state === '') {
         addPricingRow('Total', offerSubtotal);
     } else {
         // If the country is Canada, and a valid state is selected, present subtotal & tax separately
@@ -674,9 +674,19 @@ function registerUpsellLinks() {
 }
 
 function submitUpsell(callbackUrl, additionalParams) {
-    const url = new URL(callbackUrl);
-    additionalParams.forEach(p => url.searchParams.append(p.name, p.value));
-    window.location.href = url.toString();
+    // Due to a quirk of how FunnelFlux handles url params, POST to callbackUrl w/ params as form-data
+    const tempForm = document.createElement('form');
+    tempForm.display = 'none';
+    tempForm.action = callbackUrl;
+    tempForm.method = 'POST';
+    document.body.appendChild(tempForm);
+    additionalParams.forEach(p => {
+        const input = document.createElement('input');
+        input.name = p.name;
+        input.value = p.value;
+        tempForm.appendChild(input);
+    })
+    tempForm.submit();
 }
 
 window.addEventListener('DOMContentLoaded', (e) => {


### PR DESCRIPTION
- This is a workaround for FunnelFlux's strange handling of query params in subsequent nodes
- Updated test form's callbackUrl to point to a temp test link (`Action 1`):  
![image](https://user-images.githubusercontent.com/69593277/106957078-c817fa00-66f4-11eb-9623-cc8273ec3b53.png)
