### PR TITLE
Change DOMContentLoaded event listener to an IIFE

### DIFF
--- a/checkout-form-manager.js
+++ b/checkout-form-manager.js
@@ -687,7 +687,7 @@ function submitUpsell(callbackUrl, additionalParams) {
     window.location.href = url.toString();
 }
 
-window.addEventListener('DOMContentLoaded', (e) => {
+(function () {
     if (getCheckoutElem()) addCheckoutForm();
     registerUpsellLinks();
-});
+})();


### PR DESCRIPTION
An Immediately-Invoked Function Expression (IIFE) executes immediately after it’s created. By switching this event listener to an IIFE, execution relies on script placement rather than the specified DOMContentLoaded event. Doing this gives us the ability to use our script in Google Tag Manager (GTM), as GTM is not able to fire until after the DOMContentLoaded event. It does, however, require us to place it after the checkout div in order to render properly.