### PR TITLE
Checkout Style updated to use class instead of Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Put in `<head>`:
 ```
 Add div where you want to render Form:
 ```
-<div id='aa-checkout-div'></div
+<div id="aa-checkout-div" class="aa-checkout-div"></div
 ```
 In case, you use any other id than `aa-checkout-div` say `checkout-div` for example, we will need this code in `<body>` at the bottom:
 ```

--- a/checkout/default.css
+++ b/checkout/default.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
-#aa-checkout-div{
+.aa-checkout-div{
     position:relative;
     display:block;
     font-family: 'Montserrat', sans-serif;
@@ -10,24 +10,24 @@
     width:800px;
     max-width:100%;
 }
-#aa-checkout-div div{
+.aa-checkout-div div{
     position:relative;
     box-sizing: border-box;
 }
-#aa-checkout-div h3{
+.aa-checkout-div h3{
     margin:1rem 0 1rem 0;
     font-family: 'Montserrat', sans-serif;
     font-weight:bold;
 }
-#aa-checkout-div h3,  #aa-checkout-div label{
+.aa-checkout-div h3,  .aa-checkout-div label{
     font-size:1.25rem;
     display:block;
 }
-#aa-checkout-div label{
+.aa-checkout-div label{
     margin-bottom:0.25rem;
     font-size:1rem
 }
-#aa-checkout-div div input, #aa-checkout-div select{
+.aa-checkout-div div input, .aa-checkout-div select{
     width:100%;
     padding:0.65rem;
     border-radius:0.25rem;
@@ -38,7 +38,7 @@
     color:#000;
     box-sizing: border-box;
 }
-#aa-checkout-div select{
+.aa-checkout-div select{
     padding-left:0.65rem;
     -webkit-appearance:none;
     -moz-appearance:none;
@@ -49,10 +49,10 @@
     background-size: 5px 5px, 5px 5px, 1px 1.5em;
     background-repeat: no-repeat;
 }
-#aa-checkout-div ::-ms-expand {
+.aa-checkout-div ::-ms-expand {
     display:none;
 }
-#aa-checkout-div .physicalCheckoutDiv {
+.aa-checkout-div .physicalCheckoutDiv {
     border-radius: 5px;
     background: #F7F2E1;
     border: 1px solid #ded2a1;
@@ -61,16 +61,16 @@
     margin-bottom:1.5rem;
     display:block;
 }
-#aa-checkout-div .physicalCheckoutDiv label{
+.aa-checkout-div .physicalCheckoutDiv label{
     font-size:12px;
     position:relative;
     top:-2px;
 }
-#aa-checkout-div .physicalCheckoutDiv h3{
+.aa-checkout-div .physicalCheckoutDiv h3{
     margin-bottom:0.5rem;
     margin-top:0;
 }
-#aa-checkout-div .checkoutErrors {
+.aa-checkout-div .checkoutErrors {
     color: #b82418;
     background:#fef8f8;
     border:1px solid #e8c6c3;
@@ -80,31 +80,31 @@
     margin-bottom:1rem;
     font-size:1rem;
 }
-#aa-checkout-div .physicalCheckoutDiv label{
+.aa-checkout-div .physicalCheckoutDiv label{
     display:inline;
 }
-#aa-checkout-div input[type=checkbox]{
+.aa-checkout-div input[type=checkbox]{
     width: auto;
     display:inline;
 }
-#aa-checkout-div input:disabled{
+.aa-checkout-div input:disabled{
     background:#ccc;
     cursor:not-allowed;
 }
-#aa-checkout-div .split{
+.aa-checkout-div .split{
     width:50%;
     float:left;
     z-index:8
 }
-#aa-checkout-div .split.split-first select{
+.aa-checkout-div .split.split-first select{
     width:98%;
 }
-#aa-checkout-div .what-is-this{
+.aa-checkout-div .what-is-this{
     color:#333;
     text-decoration: underline;
     margin-bottom:1rem;
 }
-#aa-checkout-div .summary{
+.aa-checkout-div .summary{
     padding: 1rem 1rem 1rem 1rem;
     border-radius: 0.5rem;
     width: 600px;
@@ -114,29 +114,29 @@
     box-sizing: border-box;
     border:1px solid rgba(0,0,0,0.15);
 }
-#aa-checkout-div .summary p{
+.aa-checkout-div .summary p{
     width:400px;
     max-width:100%;
     margin-left:auto;
     margin-right:auto;
     font-size:1rem;
 }
-#aa-checkout-div .summary p:first-of-type, #aa-checkout-div .summary p:nth-of-type(2){
+.aa-checkout-div .summary p:first-of-type, .aa-checkout-div .summary p:nth-of-type(2){
     margin-bottom:0;
     margin-top:0;
 }
-#aa-checkout-div .summary p:first-of-type strong{
+.aa-checkout-div .summary p:first-of-type strong{
     color:#472f85;
 }
-#aa-checkout-div p.terms{
+.aa-checkout-div p.terms{
     margin:1rem auto!important;
     font-size:12px;
 }
-#aa-checkout-div .terms a{
+.aa-checkout-div .terms a{
     color:#656565;
     text-decoration: underline;
 }
-#aa-checkout-div .summary button{
+.aa-checkout-div .summary button{
     background:linear-gradient(#654DA3,#472F85 50%);
     padding: 0.85rem 5rem;
     height: auto;
@@ -153,25 +153,25 @@
     cursor: pointer;
     font-family: 'Montserrat', sans-serif;
 }
-#aa-checkout-div .summary button:hover{
+.aa-checkout-div .summary button:hover{
     background:linear-gradient(#e5b202,#d1a402 50%)
 }
-#aa-checkout-div .summary img{
+.aa-checkout-div .summary img{
     display:inline;
 }
-#aa-checkout-div p.privacy{
+.aa-checkout-div p.privacy{
     margin-bottom:1rem!important;
     font-size:14px;
 }
 @media screen and (max-width:400px){
-    #aa-checkout-div .summary button{
+    .aa-checkout-div .summary button{
         padding:0.85rem 1rem;
         width:100%;
     }
-    #aa-checkout-div .terms a{
+    .aa-checkout-div .terms a{
         display:block;
     }
-    #aa-checkout-div p.privacy, #aa-checkout-div p.questions{
+    .aa-checkout-div p.privacy, .aa-checkout-div p.questions{
         font-size:12px;
     }
 }

--- a/checkout/usage/autoload_div.html
+++ b/checkout/usage/autoload_div.html
@@ -7,6 +7,7 @@
 
 <body>
 <div id="aa-checkout-div"
+     class="aa-checkout-div"
      data-product-variant-id="1360"
      data-checkout-button-text="Buy Me"
      data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374"

--- a/checkout/usage/autoload_div_physical_checkout.html
+++ b/checkout/usage/autoload_div_physical_checkout.html
@@ -7,6 +7,7 @@
 
 <body>
 <div id="aa-checkout-div"
+     class="aa-checkout-div"
      data-product-variant-id="1360"
      data-checkout-button-text="Buy Me"
      data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374"

--- a/checkout/usage/autoload_div_product_selection.html
+++ b/checkout/usage/autoload_div_product_selection.html
@@ -16,6 +16,7 @@
 <br>
 <hr>
 <div id="aa-checkout-div"
+     class="aa-checkout-div"
      data-product-variant-id="608"
      data-checkout-button-text="Buy Me"
      data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374"

--- a/checkout/usage/autoload_div_product_selection_toggle_digital_physical.html
+++ b/checkout/usage/autoload_div_product_selection_toggle_digital_physical.html
@@ -16,6 +16,7 @@
 <br>
 <hr>
 <div id="aa-checkout-div"
+     class="aa-checkout-div"
      data-product-variant-id="608"
      data-checkout-button-text="Buy Me"
      data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374"

--- a/checkout/usage/autoload_div_without_data_properties.html
+++ b/checkout/usage/autoload_div_without_data_properties.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-<div id="checkout-div"></div>
+<div id="checkout-div" class="aa-checkout-div"></div>
 <!--Add Form Style-->
 <link rel="stylesheet" href="../default.css" />
 <!--Add VueJS-->

--- a/checkout/usage/form_render_event.html
+++ b/checkout/usage/form_render_event.html
@@ -8,6 +8,7 @@
 <button id="checkout-btn">Load Checkout Form</button>
 <hr>
 <div id="aa-checkout-div"
+     class="aa-checkout-div"
      data-product-variant-id="1360"
      data-checkout-button-text="Buy Me"
      data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374"

--- a/checkout/usage/form_render_event_product_selection.html
+++ b/checkout/usage/form_render_event_product_selection.html
@@ -13,7 +13,7 @@
     <br>
     <button id="product-variant-selection">Buy Now</button>
 </div>
-<div id="checkout-div"></div>
+<div id="checkout-div" class="aa-checkout-div"></div>
 <!--Add Form Style-->
 <link rel="stylesheet" href="../default.css" />
 <!--Add VueJS-->

--- a/checkout/usage/form_render_event_without_data_properties.html
+++ b/checkout/usage/form_render_event_without_data_properties.html
@@ -7,7 +7,7 @@
 <body>
 <button id="checkout-btn">Load Checkout Form</button>
 <hr>
-<div id="checkout-div"></div>
+<div id="checkout-div" class="aa-checkout-div"></div>
 <!--Add Form Style-->
 <link rel="stylesheet" href="../default.css" />
 <!--Add VueJS-->

--- a/checkout/usage/index.html
+++ b/checkout/usage/index.html
@@ -15,13 +15,14 @@
 </ul>
 <h3>How to Use:</h3>
 <p>App need to know where to render Form, this is achieved by creating a div and using JS to render Checkout Form, whether it is needed on Page Load or a particular event like Product Selection or button click.</p>
+<p><b>Note:</b> To make sure, Form is rendered using correct styling, make sure to set class of div to be `aa-checkout-div`</p>
 <p>
     Div can be created either with or without data-properties. Here are examples:<br><br>
     <u>With data-properties:</u>
 </p>
 <h4>Declaration</h4>
 <code>
-    <b>&lt;div id="checkout-div" data-product-variant-id="1360" data-shipping-tag="1" data-checkout-button-text="Buy Me" data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374" data-checkout-form-type="digital"&gt;&lt;/div&gt;</b>
+    <b>&lt;div id="checkout-div" class="aa-checkout-div" data-product-variant-id="1360" data-shipping-tag="1" data-checkout-button-text="Buy Me" data-successful-checkout-url="https://flux.astrologyanswers.com/?flux_action=1&flux_f=1061367355000511979&flux_ffn=1095133337314859374" data-checkout-form-type="digital"&gt;&lt;/div&gt;</b>
     <br>In this example, we can actually get rid off <b>data-checkout-button-text="Buy Me"</b>, and <b>data-checkout-form-type="digital"</b> since these are default values. There is more information about setting up configuration later
 </code>
 <h4>Javascript</h4>
@@ -33,7 +34,7 @@
         &lt;\script&gt;
     </b>
 </code>
-<p>Note: If you name div as `aa-checkout-div`, you won't need to add Javascript at bottom of page</p>
+<p>Note: If you set id of your div as `aa-checkout-div`, you won't need to add Javascript at bottom of page</p>
 <p><u>Without any data-property:</u></p>
 <h4>Declaration</h4>
 <code><b>&lt;div id="checkout-div"&gt;&lt;/div&gt;</b></code>

--- a/dist/checkout/default.css
+++ b/dist/checkout/default.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
-#aa-checkout-div{
+.aa-checkout-div{
     position:relative;
     display:block;
     font-family: 'Montserrat', sans-serif;
@@ -10,24 +10,24 @@
     width:800px;
     max-width:100%;
 }
-#aa-checkout-div div{
+.aa-checkout-div div{
     position:relative;
     box-sizing: border-box;
 }
-#aa-checkout-div h3{
+.aa-checkout-div h3{
     margin:1rem 0 1rem 0;
     font-family: 'Montserrat', sans-serif;
     font-weight:bold;
 }
-#aa-checkout-div h3,  #aa-checkout-div label{
+.aa-checkout-div h3,  .aa-checkout-div label{
     font-size:1.25rem;
     display:block;
 }
-#aa-checkout-div label{
+.aa-checkout-div label{
     margin-bottom:0.25rem;
     font-size:1rem
 }
-#aa-checkout-div div input, #aa-checkout-div select{
+.aa-checkout-div div input, .aa-checkout-div select{
     width:100%;
     padding:0.65rem;
     border-radius:0.25rem;
@@ -38,7 +38,7 @@
     color:#000;
     box-sizing: border-box;
 }
-#aa-checkout-div select{
+.aa-checkout-div select{
     padding-left:0.65rem;
     -webkit-appearance:none;
     -moz-appearance:none;
@@ -49,10 +49,10 @@
     background-size: 5px 5px, 5px 5px, 1px 1.5em;
     background-repeat: no-repeat;
 }
-#aa-checkout-div ::-ms-expand {
+.aa-checkout-div ::-ms-expand {
     display:none;
 }
-#aa-checkout-div .physicalCheckoutDiv {
+.aa-checkout-div .physicalCheckoutDiv {
     border-radius: 5px;
     background: #F7F2E1;
     border: 1px solid #ded2a1;
@@ -61,16 +61,16 @@
     margin-bottom:1.5rem;
     display:block;
 }
-#aa-checkout-div .physicalCheckoutDiv label{
+.aa-checkout-div .physicalCheckoutDiv label{
     font-size:12px;
     position:relative;
     top:-2px;
 }
-#aa-checkout-div .physicalCheckoutDiv h3{
+.aa-checkout-div .physicalCheckoutDiv h3{
     margin-bottom:0.5rem;
     margin-top:0;
 }
-#aa-checkout-div .checkoutErrors {
+.aa-checkout-div .checkoutErrors {
     color: #b82418;
     background:#fef8f8;
     border:1px solid #e8c6c3;
@@ -80,31 +80,31 @@
     margin-bottom:1rem;
     font-size:1rem;
 }
-#aa-checkout-div .physicalCheckoutDiv label{
+.aa-checkout-div .physicalCheckoutDiv label{
     display:inline;
 }
-#aa-checkout-div input[type=checkbox]{
+.aa-checkout-div input[type=checkbox]{
     width: auto;
     display:inline;
 }
-#aa-checkout-div input:disabled{
+.aa-checkout-div input:disabled{
     background:#ccc;
     cursor:not-allowed;
 }
-#aa-checkout-div .split{
+.aa-checkout-div .split{
     width:50%;
     float:left;
     z-index:8
 }
-#aa-checkout-div .split.split-first select{
+.aa-checkout-div .split.split-first select{
     width:98%;
 }
-#aa-checkout-div .what-is-this{
+.aa-checkout-div .what-is-this{
     color:#333;
     text-decoration: underline;
     margin-bottom:1rem;
 }
-#aa-checkout-div .summary{
+.aa-checkout-div .summary{
     padding: 1rem 1rem 1rem 1rem;
     border-radius: 0.5rem;
     width: 600px;
@@ -114,29 +114,29 @@
     box-sizing: border-box;
     border:1px solid rgba(0,0,0,0.15);
 }
-#aa-checkout-div .summary p{
+.aa-checkout-div .summary p{
     width:400px;
     max-width:100%;
     margin-left:auto;
     margin-right:auto;
     font-size:1rem;
 }
-#aa-checkout-div .summary p:first-of-type, #aa-checkout-div .summary p:nth-of-type(2){
+.aa-checkout-div .summary p:first-of-type, .aa-checkout-div .summary p:nth-of-type(2){
     margin-bottom:0;
     margin-top:0;
 }
-#aa-checkout-div .summary p:first-of-type strong{
+.aa-checkout-div .summary p:first-of-type strong{
     color:#472f85;
 }
-#aa-checkout-div p.terms{
+.aa-checkout-div p.terms{
     margin:1rem auto!important;
     font-size:12px;
 }
-#aa-checkout-div .terms a{
+.aa-checkout-div .terms a{
     color:#656565;
     text-decoration: underline;
 }
-#aa-checkout-div .summary button{
+.aa-checkout-div .summary button{
     background:linear-gradient(#654DA3,#472F85 50%);
     padding: 0.85rem 5rem;
     height: auto;
@@ -153,25 +153,25 @@
     cursor: pointer;
     font-family: 'Montserrat', sans-serif;
 }
-#aa-checkout-div .summary button:hover{
+.aa-checkout-div .summary button:hover{
     background:linear-gradient(#e5b202,#d1a402 50%)
 }
-#aa-checkout-div .summary img{
+.aa-checkout-div .summary img{
     display:inline;
 }
-#aa-checkout-div p.privacy{
+.aa-checkout-div p.privacy{
     margin-bottom:1rem!important;
     font-size:14px;
 }
 @media screen and (max-width:400px){
-    #aa-checkout-div .summary button{
+    .aa-checkout-div .summary button{
         padding:0.85rem 1rem;
         width:100%;
     }
-    #aa-checkout-div .terms a{
+    .aa-checkout-div .terms a{
         display:block;
     }
-    #aa-checkout-div p.privacy, #aa-checkout-div p.questions{
+    .aa-checkout-div p.privacy, .aa-checkout-div p.questions{
         font-size:12px;
     }
 }


### PR DESCRIPTION
Changed checkout Form CSS to work with class instead of id, this solves the issue where we don't want to autoload checkout div which breaks the style. closes #53 
Before merging this PR, we would need to update to use class `aa-checkout-div` anywhere this plugin is used otherwise style will break on those pages