### PR TITLE
upsell link registration

### DIFF
--- a/checkout-form-manager-test.html
+++ b/checkout-form-manager-test.html
@@ -19,7 +19,13 @@
     <a class="upsell-link"
        href="#"
        data-action-url="https://flux2.astrologyanswers.com/?flux_action=1&flux_f=1147020355678920015&flux_ffn=1147020973846306320">Upsell 4</a>
-    <br><code>Open Console and type `checkout.upsell.verify()` to verify if everything is fine for Upsell page, or you can manually run `checkout.upsell.verifyLinks()` to check if upsell links are fine. For checking if URL has necessary values (currently Hash and Token are required), you can use `checkout.upsell.verifyURLParameters()`</code>
+    <br><code>Please use Console and type `checkout.upsell.verify()` to verify if everything is fine for Upsell page, or you can manually run `checkout.upsell.verifyLinks()` to check if upsell links are fine. For checking if URL has necessary values (currently Hash and Token are required), you can use `checkout.upsell.verifyURLParameters()`</code>
+
+    <h2>Upsell Links Registration via JS code</h2>
+    <a href="#" id ="element31">Upsell 5</a>
+    <a href="#" id ="element32">Upsell 6</a>
+    <a href="#" id ="element33">Upsell 7</a>
+    <br><code>Due to Instapage limitations, we have new upsell link registrations method. Use `checkout.upsell.registerElements(elmIdentityCollection,actionUrl, offerId)` on create upsell link programmatically</code>
 
     <h2>Checkout Form</h2>
     <div id="aa-checkout-div"
@@ -31,4 +37,8 @@
     ></div>
 
     <script src="checkout-form-manager.js"></script>
+    <script>
+        checkout.upsell.registerElements('#element31, #element32','https://flux2.astrologyanswers.com/?flux_action=1&flux_f=1147020355678920015&flux_ffn=1147020973846306320','1361');
+        checkout.upsell.registerElements('#element33','https://flux2.astrologyanswers.com/?flux_action=1&flux_f=1147020355678920015&flux_ffn=1147020973846306320');
+    </script>
 </body>

--- a/checkout-form-manager.js
+++ b/checkout-form-manager.js
@@ -734,20 +734,6 @@ const checkout = {
             }
         },
 
-        registerElement: function (elmIdentity, actionUrl, offerId='0') {
-            let elm = document.querySelector(elmIdentity);
-            if(!elm) {
-                console.error(`Upsell Registration failed. Unable to find element with definition : ${elmIdentity}`);
-                return;
-            }
-            elm.classList.add(this.className);
-            if(elm.tagName === 'a') {
-                elm.href = 'javascript:void(0);';
-            }
-            elm.dataset.actionUrl = actionUrl;
-            elm.dataset.offerId = offerId;
-        },
-
         verify: function () {
             this.verifyLinks();
             this.verifyURLParameters();

--- a/checkout-form-manager.js
+++ b/checkout-form-manager.js
@@ -714,6 +714,37 @@ const checkout = {
         processing: false,
         className: 'upsell-link',
 
+        registerElements: function (elmIdentityCollection, actionUrl, offerId='0') {
+            let _upsell_registrations = 0;
+            let _upsell_registration_requests = (elmIdentityCollection.match(/,/g) || []).length + 1;
+            document.querySelectorAll(elmIdentityCollection).forEach(elm => {
+                elm.classList.add(this.className);
+                elm.dataset.actionUrl = actionUrl;
+                elm.dataset.offerId = offerId;
+                _upsell_registrations++ ;
+            });
+            if(_upsell_registrations) {
+                console.log(`Successfully registered ${_upsell_registrations} Upsell Links`);
+            }
+            if(_upsell_registrations<_upsell_registration_requests) {
+                console.error(`Unable to process ${_upsell_registration_requests-_upsell_registrations} upsell registrations.`);
+            }
+        },
+
+        registerElement: function (elmIdentity, actionUrl, offerId='0') {
+            let elm = document.querySelector(elmIdentity);
+            if(!elm) {
+                console.error(`Upsell Registration failed. Unable to find element with definition : ${elmIdentity}`);
+                return;
+            }
+            elm.classList.add(this.className);
+            if(elm.tagName === 'a') {
+                elm.href = 'javascript:void(0);';
+            }
+            elm.dataset.actionUrl = actionUrl;
+            elm.dataset.offerId = offerId;
+        },
+
         verify: function () {
             this.verifyLinks();
             this.verifyURLParameters();
@@ -755,6 +786,7 @@ const checkout = {
 
         process: function (elm) {
             if(this.processing) {
+                console.error('Cannot process multiple Upsells');
                 return;
             }
             this.processing = true;

--- a/checkout-form-manager.js
+++ b/checkout-form-manager.js
@@ -719,6 +719,9 @@ const checkout = {
             let _upsell_registration_requests = (elmIdentityCollection.match(/,/g) || []).length + 1;
             document.querySelectorAll(elmIdentityCollection).forEach(elm => {
                 elm.classList.add(this.className);
+                if(elm.tagName === 'A') {
+                    elm.href = 'javascript:void(0);';
+                }
                 elm.dataset.actionUrl = actionUrl;
                 elm.dataset.offerId = offerId;
                 _upsell_registrations++ ;


### PR DESCRIPTION
resolves #62 
duplicate of #61 , this PR used checkout.upsell for creating new method unlike #61 where it is global method. 
using `'javascript:void(0);'` instead of `#` for hyperlink after reviewing #61 